### PR TITLE
Add human readable timestamp

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,7 +18,8 @@ class cowBot(threading.Thread):
     self.q = q
     self.rdr = newsReader(conf['news']['host'], conf['news']['port'],
                           conf['news']['user'], conf['news']['pass'],
-                          conf['news']['last'], conf['news']['auth'])
+                          conf['news']['last'], conf['news']['auth'],
+                          conf['news']['timezone'])
     self.db = dataBase(conf['db']['host'], conf['db']['user'],
                        conf['db']['pass'], conf['db']['name'], self.rdr)
     self.mention_manager = mentionManager(self.db, self)

--- a/driver.py
+++ b/driver.py
@@ -19,7 +19,8 @@ def getConf(storage):
       'port': 443,
       'user': 'UNAME',
       'pass': 'PASS',
-      'last': 'lpost_file'
+      'last': 'lpost_file',
+      'timezone': "3.00"  # Timezone difference to UTC-Z in the form of: "x.yz" or "-x.yz"
   }
   conf['db'] = {
       'host': 'HOST',

--- a/driver.py
+++ b/driver.py
@@ -20,7 +20,7 @@ def getConf(storage):
       'user': 'UNAME',
       'pass': 'PASS',
       'last': 'lpost_file',
-      'timezone': "3.00"  # Timezone difference to UTC-Z in the form of: "x.yz" or "-x.yz"
+      'timezone': 3  # Timezone difference to UTC-Z in the form of: x or -x
   }
   conf['db'] = {
       'host': 'HOST',

--- a/newsparser.py
+++ b/newsparser.py
@@ -19,10 +19,8 @@ def getHumanReadableDate(date):
   rawDate, localTimezone = date
   # Parse the raw format and add localTimezone's hour difference.
 
-  hours = localTimezone[0]
-  minutes = localTimezone[1]
   machineDate = datetime.datetime.strptime(rawDate.split('.')[0],
-    "%Y-%m-%dT%H:%M:%S") + datetime.timedelta(hours=hours, minutes=minutes)
+    "%Y-%m-%dT%H:%M:%S") + datetime.timedelta(hours=localTimezone)
   # return the human readable from, refer to datetime.strftime for format
   # options.
   # an example of current format: 03 Feb 2020, 18:30:00

--- a/newsparser.py
+++ b/newsparser.py
@@ -10,6 +10,25 @@ def isPlusOne(msg):
   return msg.startswith("+1") and len(msg) < 10
 
 
+def getHumanReadableDate(date):
+  # Date is expected to be a tuple of two elements, from newsreader.
+  # date[0] -> message's date in raw form: %Y:%m:%dT%H:%M:%S.xxZ
+  # where 'xx's and Z represent nanosecs(?) and the UTC +0 respectively.
+  # date[1] -> list of timezone difference to localzone, Turkey's is UTC 3.00,
+  #            so it is [3, 0] representing hours and minutes by default.
+  rawDate, localTimezone = date
+  # Parse the raw format and add localTimezone's hour difference.
+
+  hours = localTimezone[0]
+  minutes = localTimezone[1]
+  machineDate = datetime.datetime.strptime(rawDate.split('.')[0],
+    "%Y-%m-%dT%H:%M:%S") + datetime.timedelta(hours=hours, minutes=minutes)
+  # return the human readable from, refer to datetime.strftime for format
+  # options.
+  # an example of current format: 03 Feb 2020, 18:30:00
+  return machineDate.strftime("%d %b %Y, %H:%M:%S")
+
+
 class articleParser(HTMLParser):
 
   def __init__(self):
@@ -40,7 +59,7 @@ class newsArticle:
     self.author_displayname = author[1]
     self.topic = topic
     self.subject = subject
-    self.date = date
+    self.date = getHumanReadableDate(date)
     self.raw_msg = raw_msg
     self.raw_html = raw_html
     self.mention_manager = mention_manager

--- a/newsreader.py
+++ b/newsreader.py
@@ -14,8 +14,7 @@ class newsReader:
   def __init__(self, host, port, uname, pw, lfile, auth, timezone):
     self.conparams = [host, port, uname, pw, auth]
     self.lfile = lfile
-    self.timezone = [int(timezone[:-3]), 
-                    int(timezone[-2:]) if timezone[0] != '-' else -int(timezone[-2:])]
+    self.timezone = timezone
     self.initialized = False
     self.initConnection()
 

--- a/newsreader.py
+++ b/newsreader.py
@@ -11,9 +11,11 @@ from newsparser import newsArticle
 
 class newsReader:
 
-  def __init__(self, host, port, uname, pw, lfile, auth):
+  def __init__(self, host, port, uname, pw, lfile, auth, timezone):
     self.conparams = [host, port, uname, pw, auth]
     self.lfile = lfile
+    self.timezone = [int(timezone[:-3]), 
+                    int(timezone[-2:]) if timezone[0] != '-' else -int(timezone[-2:])]
     self.initialized = False
     self.initConnection()
 
@@ -167,7 +169,7 @@ class newsReader:
               (post['username'], post['name']),
               self.categories[topic['category_id']],
               topic['title'],
-              post['created_at'],
+              (post['created_at'], self.timezone),
               post['raw'],  # raw msg (markdown)
               post['cooked'],  # mgs in html format
               mention_manager))


### PR DESCRIPTION
This commit presents a human-readable date format for message timestamps.

Why?

* Unfortunately, the default timestamp `%Y:%m:%dT%H:%M:%S.xxZ` is not
human-readable.

Changes:

* Users can get the timestamp in more readable form of `%d %b %Y, %H:%M:%S`.
As an example, `03 Feb 2020, 18:30:00`

Affected Classes:

* `config` file gets a new member under `news` keyword, namely
timestamp. It represents the user's local timezone in the UTC format. As
an example, Turkey's local timezone is UTC +3.00, so the timezone field
should be "3.00".

* `newsArticle` gets a new function, `getHumanReadableDate`, accepting
raw timestamp and local timezone. The local timestamp is parsed to the
form of a list of two integers, they represent hours and minutes
respectively.

* `newsReader` also gets a new member, called timezone. Since we always
create `newsArticle`, performing the parsing operation in the
constructor made a lot of sense, avoiding unnecessary computations.

This commit should resolve issue #10.