### PR TITLE
Fixed markdown styling while mentioning alias

### DIFF
--- a/mention_manager.py
+++ b/mention_manager.py
@@ -12,8 +12,8 @@ class mentionManager:
     self.student_no_matcher = re.compile("e?\d{6,7}")
     self.db = db
     self.cow_bot = cow_bot
-    self.mention_text = "Your alias <b>{}</b> has been mentioned in " + \
-            "newsgroup: <b>{}</b> with header: <b>{}</b> at line: {}."
+    self.mention_text = "Your alias *{}* has been mentioned in " + \
+            "newsgroup: *{}* with header: *{}* at line: {}."
 
   def sendMention(self, cid, alias, newsgroup, header, line_no):
     return self.cow_bot.sendMsg(

--- a/mention_manager.py
+++ b/mention_manager.py
@@ -1,5 +1,4 @@
 import re
-import html
 
 from markdownrenderer import escape
 

--- a/mention_manager.py
+++ b/mention_manager.py
@@ -2,6 +2,7 @@ import re
 
 from markdownrenderer import escape
 
+
 class mentionManager:
 
   def isStudentNumber(self, msg):
@@ -19,8 +20,8 @@ class mentionManager:
     return self.cow_bot.sendMsg(
         cid,
         self.mention_text.format(
-            escape(alias), escape(newsgroup), escape(header),
-            line_no), escaped=True)
+            escape(alias), escape(newsgroup), escape(header), line_no),
+        escaped=True)
 
   def getMinimalStudentNo(self, student_no):
     base = student_no

--- a/mention_manager.py
+++ b/mention_manager.py
@@ -1,6 +1,7 @@
 import re
 import html
 
+from markdownrenderer import escape
 
 class mentionManager:
 
@@ -13,14 +14,14 @@ class mentionManager:
     self.db = db
     self.cow_bot = cow_bot
     self.mention_text = "Your alias *{}* has been mentioned in " + \
-            "newsgroup: *{}* with header: *{}* at line: {}."
+            "newsgroup: *{}* with header: *{}* at line: {}\."
 
   def sendMention(self, cid, alias, newsgroup, header, line_no):
     return self.cow_bot.sendMsg(
         cid,
         self.mention_text.format(
-            html.escape(alias), html.escape(newsgroup), html.escape(header),
-            line_no))
+            escape(alias), escape(newsgroup), escape(header),
+            line_no), escaped=True)
 
   def getMinimalStudentNo(self, student_no):
     base = student_no
@@ -34,7 +35,7 @@ class mentionManager:
     line_no = 0
     for raw_line in content.split("\n"):
       line = raw_line.strip()
-      if line.startswith("&gt"):
+      if line.startswith(">"):
         continue
       student_no = self.isStudentNumber(line)
       if student_no is not None:

--- a/mention_manager.py
+++ b/mention_manager.py
@@ -34,7 +34,7 @@ class mentionManager:
     line_no = 0
     for raw_line in content.split("\n"):
       line = raw_line.strip()
-      if line.startswith(">"):
+      if line.startswith("> "):
         continue
       student_no = self.isStudentNumber(line)
       if student_no is not None:


### PR DESCRIPTION
Today I noticed that when my alias was mentioned, I received a notification but the styling was in HTML instead of MarkdownV2. This pull request fixes that.

Example: 
```Your alias <b>2309615</b> has been mentioned in newsgroup: <b>Test</b> with header: <b>hey @2309615</b> at line: 1.```