### PR TITLE
Add a link to the posts in the messages

### DIFF
--- a/newsparser.py
+++ b/newsparser.py
@@ -30,13 +30,14 @@ def getHumanReadableDate(date):
 
 class newsArticle:
 
-  def __init__(self, author, topic, subject, date, dc_markdown,
+  def __init__(self, author, topic, subject, date, url, dc_markdown,
                mention_manager):
     self.author_username = author[0]
     self.author_displayname = author[1]
     self.topic = topic
     self.subject = subject
     self.date = getHumanReadableDate(date)
+    self.url = url
     self.dc_markdown = dc_markdown
     self.mention_manager = mention_manager
     self.broken = False
@@ -63,7 +64,8 @@ class newsArticle:
         f"Subject: {self.subject}\n"\
         f"Date: {self.date}\n"\
         f"is_plus_one: {self.isPlusOne()}"
-    return '```\n' + escape(hdr, True) + '\n```\n'
+    link_to_post = f'[Open post]({self.url})\n'
+    return link_to_post + '```\n' + escape(hdr, True) + '\n```\n'
 
   def parseMessage(self):
     if self.broken:

--- a/newsreader.py
+++ b/newsreader.py
@@ -196,6 +196,7 @@ class newsReader:
               self.categories[topic['category_id']],
               topic['title'],
               (post['created_at'], self.timezone),
+              f'{self.conparams[0]}p/{post["id"]}',
               post['raw'],  # raw msg (markdown)
               mention_manager))
     self.last_post = start


### PR DESCRIPTION
This PR adds an inline url to the beginning of each telegram message with text
`Open post`.

I've tried to put the message into various places like:
- End of the message.
- After headers.

None of these seemed to be better, but I am open for suggestions.

Fixes #20.
